### PR TITLE
refactor the unified auth gaurd and useAuthGuard

### DIFF
--- a/restock/app/(tabs)/_layout.tsx
+++ b/restock/app/(tabs)/_layout.tsx
@@ -38,7 +38,7 @@ export default function TabLayout() {
   );
 
   return (
-    <UnifiedAuthGuard requireAuth requireProfileSetup>
+    <UnifiedAuthGuard  >
       <Tabs screenOptions={screenOptions}>
         {/* Dashboard */}
         <Tabs.Screen

--- a/restock/app/auth/guards/useAuthGuard.ts
+++ b/restock/app/auth/guards/useAuthGuard.ts
@@ -34,7 +34,7 @@ export const useAuthGuard = () => {
     guardLogger.log('Redirecting to profile setup:', route);
     
     try {
-      router.replace(route);
+      router.replace(route as any);
     } catch (error) {
       guardLogger.error('Failed to redirect to profile setup:', error);
     }
@@ -44,7 +44,7 @@ export const useAuthGuard = () => {
     guardLogger.log('Redirecting to auth screen');
     
     try {
-      router.replace('/auth');
+      router.replace('/auth' as any);
     } catch (error) {
       guardLogger.error('Failed to redirect to auth:', error);
     }
@@ -54,7 +54,7 @@ export const useAuthGuard = () => {
     guardLogger.log('Redirecting to dashboard');
     
     try {
-      router.replace('/(tabs)/dashboard');
+      router.replace('/(tabs)/dashboard' as any);
     } catch (error) {
       guardLogger.error('Failed to redirect to dashboard:', error);
     }

--- a/restock/app/auth/traditional/sign-in.tsx
+++ b/restock/app/auth/traditional/sign-in.tsx
@@ -3,7 +3,7 @@ import { View, Text, TouchableOpacity, TextInput, Alert, ScrollView, KeyboardAvo
 import { Link, router } from 'expo-router';
 import { useSignIn, useAuth, useSSO, useClerk } from '@clerk/clerk-expo';
 import { SessionManager } from '../../../backend/services/session-manager';
-import { UserProfileService } from '../../../backend/services/user-profile';
+
 import { EmailAuthService } from '../../../backend/services/email-auth';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Linking from 'expo-linking';
@@ -31,14 +31,14 @@ export default function SignInScreen() {
     // If user is already authenticated and has complete profile, redirect to dashboard
     if (unifiedIsAuthenticated && unifiedUserId && !isProfileLoading && isProfileSetupComplete && hasValidProfile) {
       console.log('🚀 SignInScreen: User already authenticated with complete profile, redirecting to dashboard');
-      router.replace('/(tabs)/dashboard');
+      router.replace('/(tabs)/dashboard' as any);
       return;
     }
     
     // If user is authenticated but profile incomplete, redirect to profile setup
     if (unifiedIsAuthenticated && unifiedUserId && !isProfileLoading && !hasValidProfile) {
       console.log('🚀 SignInScreen: User authenticated but profile incomplete, redirecting to setup');
-      router.replace('/sso-profile-setup');
+      router.replace('/sso-profile-setup' as any);
       return;
     }
     
@@ -197,10 +197,10 @@ export default function SignInScreen() {
       
       if (!isProfileLoading && hasValidProfile && isProfileSetupComplete) {
         console.log('🚀 GOOGLE FLOW: Redirecting already-authenticated user with complete profile to dashboard');
-        router.replace('/(tabs)/dashboard');
+        router.replace('/(tabs)/dashboard' as any);
       } else if (!isProfileLoading && !hasValidProfile) {
         console.log('🚀 GOOGLE FLOW: Redirecting already-authenticated user without profile to setup');
-        router.replace('/sso-profile-setup');
+        router.replace('/sso-profile-setup' as any);
       } else {
         console.log('⏳ GOOGLE FLOW: User authenticated but profile loading, staying on sign-in page');
       }

--- a/restock/app/auth/traditional/sign-up.tsx
+++ b/restock/app/auth/traditional/sign-up.tsx
@@ -1,218 +1,76 @@
-import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, TextInput, Alert, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
-import { router, Link } from 'expo-router';
-import { useSignUp } from '@clerk/clerk-expo';
+import React from 'react';
+import { View, Text, TouchableOpacity, Alert } from 'react-native';
+import { useSignUp, useSSO } from '@clerk/clerk-expo';
+import * as Linking from 'expo-linking';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { EmailAuthService } from '../../../backend/services/email-auth';
+import { router } from 'expo-router';
 import { signUpStyles } from '../../../styles/components/sign-up';
-import useThemeStore from '../../stores/useThemeStore';
 
-export default function TraditionalSignUpScreen() {
+export default function SignUpScreen() {
   const { signUp, isLoaded } = useSignUp();
-  const { theme } = useThemeStore();
-  
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [errors, setErrors] = useState<{[key: string]: string}>({});
+  const { startSSOFlow } = useSSO();
 
-  const validatePassword = (password: string) => {
-    const minLength = password.length >= 8;
-    const hasUpperCase = /[A-Z]/.test(password);
-    const hasLowerCase = /[a-z]/.test(password);
-    const hasNumbers = /\d/.test(password);
-    const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
-    
-    return {
-      minLength,
-      hasUpperCase,
-      hasLowerCase,
-      hasNumbers,
-      hasSpecialChar,
-      isValid: minLength && hasUpperCase && hasLowerCase && hasNumbers && hasSpecialChar
-    };
-  };
-
-  const handlePasswordChange = (newPassword: string) => {
-    setPassword(newPassword);
-    const validation = validatePassword(newPassword);
-    
-    const newErrors: {[key: string]: string} = {};
-    if (!validation.minLength) newErrors.length = 'Password must be at least 8 characters';
-    if (!validation.hasUpperCase) newErrors.uppercase = 'Password must contain uppercase letter';
-    if (!validation.hasLowerCase) newErrors.lowercase = 'Password must contain lowercase letter';
-    if (!validation.hasNumbers) newErrors.numbers = 'Password must contain number';
-    if (!validation.hasSpecialChar) newErrors.special = 'Password must contain special character';
-    
-    setErrors(newErrors);
-  };
-
-  const onSignUpPress = async () => {
-    console.log('👤 USER ACTION: Email Sign Up button clicked', { email: email.slice(0, 3) + '***' });
-    
-    if (!email.trim()) {
-      Alert.alert('Error', 'Please enter your email address');
-      return;
-    }
-
-    if (!password.trim()) {
-      Alert.alert('Error', 'Please enter a password');
-      return;
-    }
-
-    if (password !== confirmPassword) {
-      Alert.alert('Error', 'Passwords do not match');
-      return;
-    }
-
-    const validation = validatePassword(password);
-    if (!validation.isValid) {
-      Alert.alert('Error', 'Please ensure your password meets all requirements');
-      return;
-    }
-
+  const handleGoogleSignUp = async () => {
     if (!isLoaded) return;
 
-    console.log('🚀 EMAIL FLOW: Starting traditional email/password sign up');
-    setLoading(true);
     try {
-      console.log('📧 EMAIL FLOW: Creating Clerk sign up session');
-      
-      await signUp.create({
-        emailAddress: email,
-        password: password,
+      console.log('📡 SSO FLOW: Initiating Clerk SSO flow');
+      await AsyncStorage.setItem('oauthProcessing', 'true');
+
+      const redirectUrl = Linking.createURL('/sso-profile-setup', { scheme: 'restock' });
+      const result = await startSSOFlow({
+        strategy: 'oauth_google',
+        redirectUrl,
       });
 
-      console.log('📋 EMAIL FLOW: Clerk sign up result created successfully');
-
-      // Send verification email
-      console.log('📧 EMAIL FLOW: Preparing email verification');
-      await signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
-      
-      console.log('✅ EMAIL FLOW: Verification email prepared and sent');
-      
-      // Set flag to indicate this is a new traditional auth sign-up using EmailAuthService
-      await EmailAuthService.setTraditionalSignUpFlags();
-      console.log('✅ TraditionalSignUp: Traditional sign-up flags set via EmailAuthService');
-      
-      Alert.alert(
-        'Verification Email Sent!',
-        'Please check your email and enter the verification code.',
-        [
-          {
-            text: 'OK',
-            onPress: () => {
-              router.push('/auth/traditional/verify-email');
-            }
-          }
-        ]
-      );
-    } catch (err: any) {
-      console.error('❌ EMAIL FLOW: Sign up error:', {
-        message: err.message,
-        errors: err.errors?.map((e: any) => ({ code: e.code, message: e.message })) || [],
-        fullError: err
-      });
-      const clerkMsg = err?.errors?.[0]?.message as string | undefined;
-      // Normalize duplicate email message for better UX
-      const message = clerkMsg && /already.*exist|taken|in use/i.test(clerkMsg)
-        ? 'An account with this email already exists. Please sign in or use a different email.'
-        : (clerkMsg || 'Failed to create account');
-      Alert.alert('Error', message);
-    } finally {
-      setLoading(false);
-      console.log('🔄 EMAIL FLOW: Email sign up process completed');
+      if (result.createdSessionId && result.setActive) {
+        await result.setActive({ session: result.createdSessionId });
+        console.log('✅ SSO FLOW: Session activated');
+        await AsyncStorage.removeItem('oauthProcessing');
+        router.replace('/sso-profile-setup' as any);
+      } else {
+        console.log('❌ SSO FLOW: No session created', result);
+        await AsyncStorage.removeItem('oauthProcessing');
+        Alert.alert('Sign in failed', 'No session created. Please try again.');
+      }
+    } catch (err) {
+      console.error('❌ SSO FLOW ERROR:', err);
+      await AsyncStorage.removeItem('oauthProcessing');
+      Alert.alert('Error', 'Failed to sign in with Google. Please try again.');
     }
   };
 
   return (
-      <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
-        <KeyboardAvoidingView 
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          style={signUpStyles.container}
+    <View style={signUpStyles.container}>
+      <View style={signUpStyles.titleContainer}>
+        <Text style={signUpStyles.title}>Create your account</Text>
+      </View>
+
+      <TouchableOpacity
+        style={signUpStyles.googleButton}
+        onPress={handleGoogleSignUp}
+      >
+        <Text style={signUpStyles.googleButtonText}>
+          Continue with Google
+        </Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={signUpStyles.button}
+        onPress={() => router.push('/auth/email-signup' as any)}
+      >
+        <Text style={signUpStyles.buttonText}>
+          Sign up with Email
+        </Text>
+      </TouchableOpacity>
+
+      <View style={signUpStyles.linkContainer}>
+        <TouchableOpacity
+          onPress={() => router.push('/auth/traditional/sign-in' as any)}
         >
-          <Text style={signUpStyles.title}>Create Account</Text>
-          <Text style={signUpStyles.subtitle}>
-            Sign up with email to start managing your restock operations
-          </Text>
-
-          <TouchableOpacity 
-            style={signUpStyles.googleButton}
-            onPress={() => router.push('/auth')}
-          >
-            <Text style={signUpStyles.googleButtonText}>
-              Continue with Google
-            </Text>
-          </TouchableOpacity>
-
-          <View style={signUpStyles.divider}>
-            <View style={signUpStyles.dividerLine} />
-            <Text style={signUpStyles.dividerText}>or</Text>
-            <View style={signUpStyles.dividerLine} />
-          </View>
-
-          <TextInput
-            style={signUpStyles.input}
-            placeholder="Enter your email address"
-            placeholderTextColor={theme.neutral.medium}
-            value={email}
-            onChangeText={setEmail}
-            keyboardType="email-address"
-            autoCapitalize="none"
-          />
-
-          <TextInput
-            style={[signUpStyles.input, Object.keys(errors).length > 0 && signUpStyles.inputError]}
-            placeholder="Create a password"
-            placeholderTextColor={theme.neutral.medium}
-            value={password}
-            onChangeText={handlePasswordChange}
-            secureTextEntry={true}
-            autoCapitalize="none"
-          />
-
-          {Object.keys(errors).length > 0 && (
-            <View>
-              {Object.entries(errors).map(([key, error]) => (
-                <Text key={key} style={signUpStyles.errorText}>• {error}</Text>
-              ))}
-            </View>
-          )}
-
-          <TextInput
-            style={signUpStyles.input}
-            placeholder="Confirm your password"
-            placeholderTextColor={theme.neutral.medium}
-            value={confirmPassword}
-            onChangeText={setConfirmPassword}
-            secureTextEntry={true}
-            autoCapitalize="none"
-          />
-
-          <Text style={signUpStyles.helpText}>
-            Password must be at least 8 characters with uppercase, lowercase, number, and special character
-          </Text>
-
-          <TouchableOpacity 
-            style={[signUpStyles.button, loading && signUpStyles.buttonDisabled]}
-            onPress={onSignUpPress}
-            disabled={loading}
-          >
-            <Text style={signUpStyles.buttonText}>
-              {loading ? 'Creating Account...' : 'Create Account'}
-            </Text>
-          </TouchableOpacity>
-
-          <View style={signUpStyles.linkContainer}>
-            <Text style={signUpStyles.linkText}>Already have an account? </Text>
-            <Link href="/auth/traditional/sign-in" asChild>
-              <TouchableOpacity>
-                <Text style={signUpStyles.linkTextBold}>Sign In</Text>
-              </TouchableOpacity>
-            </Link>
-          </View>
-        </KeyboardAvoidingView>
-      </ScrollView>
+          <Text style={signUpStyles.linkText}>Already have an account? Sign in</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
   );
 }

--- a/restock/app/auth/traditional/verify-email.tsx
+++ b/restock/app/auth/traditional/verify-email.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import {  Text, TouchableOpacity, TextInput, Alert, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
 import { router } from 'expo-router';
 import { useSignUp } from '@clerk/clerk-expo';
-import UnifiedAuthGuard from '../../components/UnifiedAuthGuard';
+import { UnifiedAuthGuard } from '../../components/UnifiedAuthGuard';
 import { verifyEmailStyles } from '../../../styles/components/verify-email';
 
 export default function VerifyEmailScreen() {
@@ -60,7 +60,7 @@ export default function VerifyEmailScreen() {
   };
 
   return (
-    <UnifiedAuthGuard requireNoAuth={true}>
+    <UnifiedAuthGuard >
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         style={{ flex: 1 }}

--- a/restock/app/components/UnifiedAuthGuard.tsx
+++ b/restock/app/components/UnifiedAuthGuard.tsx
@@ -1,38 +1,12 @@
-// app/components/UnifiedAuthGuard.tsx
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { View, ActivityIndicator, Text } from 'react-native';
-import { useRouter, usePathname } from 'expo-router';
 import { useUnifiedAuth } from '../auth/UnifiedAuthProvider';
 
-interface UnifiedAuthGuardProps {
-  children: React.ReactNode;
-  requireAuth?: boolean;
-  requireNoAuth?: boolean;
-  requireProfileSetup?: boolean;
-  redirectTo?: string;
-}
+export const UnifiedAuthGuard: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { isAuthenticated, userId, hasValidProfile, isLoading, isProfileLoading } = useUnifiedAuth();
 
-export const UnifiedAuthGuard: React.FC<UnifiedAuthGuardProps> = ({
-  children,
-  requireAuth,
-  requireNoAuth,
-  requireProfileSetup,
-  redirectTo,
-}) => {
-  const auth = useUnifiedAuth();
-  const router = useRouter();
-  const pathname = usePathname();
-  const [isRedirecting, setIsRedirecting] = useState(false);
-  
-  // 🔒 CRITICAL: Never interfere with auth-related routes
-  const isAuthRoute = pathname?.includes('/auth') || pathname?.includes('/welcome') || pathname?.includes('/sso-profile-setup');
-  if (isAuthRoute && !requireAuth) {
-    console.log('🛡️ UnifiedAuthGuard: Skipping guard for auth route:', pathname);
-    return <>{children}</>;
-  }
-
-  // Show loader if auth is not ready, loading, or OAuth is in progress
-  if (!auth.isReady || auth.isLoading || auth.isOAuthInProgress) {
+  // Show loader until profile is ready
+  if (!isAuthenticated || !userId || hasValidProfile === undefined || isLoading || isProfileLoading) {
     return (
       <View className="flex-1 justify-center items-center bg-white">
         <ActivityIndicator size="large" color="#000" />
@@ -41,55 +15,6 @@ export const UnifiedAuthGuard: React.FC<UnifiedAuthGuardProps> = ({
     );
   }
 
-  // Determine redirect conditions
-  const shouldRedirect = (requireAuth && !auth.isAuthenticated) ||
-                         (requireNoAuth && auth.isAuthenticated) ||
-                         (requireProfileSetup && auth.isAuthenticated && !auth.isProfileSetupComplete);
-
-  // Handle redirects in useEffect to avoid setState during render
-  useEffect(() => {
-    if (shouldRedirect && !isRedirecting) {
-      console.log('🛡️ UnifiedAuthGuard: Redirect required', {
-        requireAuth,
-        requireNoAuth, 
-        requireProfileSetup,
-        isAuthenticated: auth.isAuthenticated,
-        isProfileSetupComplete: auth.isProfileSetupComplete,
-        userId: auth.userId,
-        customRedirectTo: redirectTo
-      });
-
-      // Determine redirect destination
-      let destination = redirectTo;
-      if (!destination) {
-        if (requireAuth && !auth.isAuthenticated) {
-          destination = '/welcome';  // Unauthenticated users go to welcome
-          console.log('🛡️ UnifiedAuthGuard: Redirecting unauthenticated user to welcome');
-        } else if (requireProfileSetup && !auth.isProfileSetupComplete) {
-          destination = '/sso-profile-setup';  // Users without profiles go to setup
-          console.log('🛡️ UnifiedAuthGuard: Redirecting user without profile to setup');
-        }
-      }
-
-      if (destination) {
-        setIsRedirecting(true);
-        console.log('🛡️ UnifiedAuthGuard: Executing redirect to:', destination);
-        router.replace(destination as any);
-      }
-    }
-  }, [shouldRedirect, isRedirecting, auth.isAuthenticated, auth.isProfileSetupComplete, auth.userId, requireAuth, requireNoAuth, requireProfileSetup, redirectTo, router]);
-
-  // Show redirecting screen if redirect is in progress
-  if (shouldRedirect || isRedirecting) {
-    return (
-      <View className="flex-1 justify-center items-center bg-white">
-        <ActivityIndicator size="small" color="#666" />
-        <Text>Redirecting...</Text>
-      </View>
-    );
-  }
-
   return <>{children}</>;
 };
-
 UnifiedAuthGuard.displayName = 'UnifiedAuthGuard';


### PR DESCRIPTION


***Let AuthRouter only handle the initial global routing, e.g., landing page, SSO setup, default tab.**

***Let UnifiedAuthGuard only block access to protected screens and show a loader if profile isn’t ready.**

**This eliminates the infinite loop,logs and  keeps separation of concerns**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced Google-based SSO sign-up with a “Continue with Google” flow, automatic session activation, and redirect to profile setup.
  - Kept an email sign-up path accessible via a dedicated screen.
- Refactor
  - Simplified authentication guard and routing for clearer, deterministic navigation.
  - Authenticated users remain on allowed tabs or are routed to the dashboard; incomplete profiles go to profile setup; unauthenticated users go to Welcome/Auth.
  - Streamlined loading state with a compact spinner and message.
  - Reduced friction and UI complexity in the sign-up experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->